### PR TITLE
feat: Add lazy rendering for map pins based on viewport

### DIFF
--- a/frontend/src/app/Components/MapBox.tsx
+++ b/frontend/src/app/Components/MapBox.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
+import { debounce, Bounds, PinData, isPointInBounds } from "./utils";
+import pinsData from "./pins.json";
 
 type MapBoxProps = {
   width?: string;
@@ -21,6 +23,69 @@ const MapBox = ({ width = "100vw", height = "100vh" }: MapBoxProps) => {
     lng: number;
     lat: number;
   } | null>(null);
+  // Store current bounds and visible pins
+  const [currentBounds, setCurrentBounds] = useState<Bounds | null>(null);
+  const [visiblePins, setVisiblePins] = useState<PinData[]>([]);
+
+  // Function to get current map bounds
+  const getBounds = useCallback((): Bounds | null => {
+    if (!mapRef.current) return null;
+    
+    const bounds = mapRef.current.getBounds();
+    if (!bounds) return null;
+    
+    return {
+      sw: [bounds.getWest(), bounds.getSouth()],
+      ne: [bounds.getEast(), bounds.getNorth()]
+    };
+  }, []);
+
+  // Function to filter pins based on bounds
+  const filterPinsByBounds = useCallback((bounds: Bounds): PinData[] => {
+    return pinsData.filter(pin => isPointInBounds(pin, bounds));
+  }, []);
+
+  // Function to clear all markers
+  const clearAllMarkers = useCallback(() => {
+    markersRef.current.forEach(marker => marker.remove());
+    markersRef.current = [];
+  }, []);
+
+  // Function to render pins
+  const renderPins = useCallback((pins: PinData[]) => {
+    if (!mapRef.current) return;
+
+    clearAllMarkers();
+
+    pins.forEach(pin => {
+      const marker = new mapboxgl.Marker()
+        .setLngLat([pin.lng, pin.lat])
+        .addTo(mapRef.current!);
+
+      // Add click event to show pin info
+      marker.getElement().addEventListener("click", function (ev) {
+        ev.stopPropagation(); // Prevent map click event
+        console.log("Pin clicked:", pin);
+        // You can add a popup or tooltip here
+      });
+
+      markersRef.current.push(marker);
+    });
+  }, [clearAllMarkers]);
+
+  // Debounced function to update visible pins
+  const debouncedUpdatePins = useCallback(
+    debounce(() => {
+      const bounds = getBounds();
+      if (!bounds) return;
+
+      setCurrentBounds(bounds);
+      const filteredPins = filterPinsByBounds(bounds);
+      setVisiblePins(filteredPins);
+      renderPins(filteredPins);
+    }, 300), // 300ms debounce
+    [getBounds, filterPinsByBounds, renderPins]
+  );
 
   useEffect(() => {
     mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
@@ -32,6 +97,19 @@ const MapBox = ({ width = "100vw", height = "100vh" }: MapBoxProps) => {
         zoom: 9,
         style: "mapbox://styles/mapbox/streets-v11",
       });
+
+      // Add moveend and zoomend event listeners
+      mapRef.current.on("moveend", debouncedUpdatePins);
+      mapRef.current.on("zoomend", debouncedUpdatePins);
+
+      // Initial pin rendering
+      const initialBounds = getBounds();
+      if (initialBounds) {
+        const initialPins = filterPinsByBounds(initialBounds);
+        setCurrentBounds(initialBounds);
+        setVisiblePins(initialPins);
+        renderPins(initialPins);
+      }
 
       // Add click event to drop a pin and log coordinates
       mapRef.current.on("click", (e: mapboxgl.MapMouseEvent) => {
@@ -63,11 +141,10 @@ const MapBox = ({ width = "100vw", height = "100vh" }: MapBoxProps) => {
 
     return () => {
       // Remove all markers
-      markersRef.current.forEach((marker) => marker.remove());
-      markersRef.current = [];
+      clearAllMarkers();
       mapRef.current?.remove();
     };
-  }, []);
+  }, [debouncedUpdatePins, getBounds, filterPinsByBounds, renderPins, clearAllMarkers]);
 
   return (
     <>
@@ -77,7 +154,20 @@ const MapBox = ({ width = "100vw", height = "100vh" }: MapBoxProps) => {
         className="map-container"
       />
 
-      {showPinOverlay && ( //Text inside pin drop overlay
+      {/* Debug info overlay */}
+      <div className="fixed top-4 left-4 backdrop-blur-lg bg-white/30 border border-white/60 rounded-2xl shadow-lg p-4 text-black">
+        <p className="font-semibold text-sm">Viewport Info</p>
+        <p className="text-xs">Visible Pins: {visiblePins.length}</p>
+        <p className="text-xs">Total Pins: {pinsData.length}</p>
+        {currentBounds && (
+          <>
+            <p className="text-xs">SW: [{currentBounds.sw[0].toFixed(3)}, {currentBounds.sw[1].toFixed(3)}]</p>
+            <p className="text-xs">NE: [{currentBounds.ne[0].toFixed(3)}, {currentBounds.ne[1].toFixed(3)}]</p>
+          </>
+        )}
+      </div>
+
+      {showPinOverlay && lastCoords && ( //Text inside pin drop overlay
         <div className="fixed bottom-10 p-4 right-10 backdrop-blur-lg bg-white/30 border border-white/60 rounded-2xl shadow-lg w-80 h-100 text-black">
           <p className="font-semibold text-lg text-black">You dropped a pin!</p>
           <p className="font-sm"> Longitude: {lastCoords.lng.toFixed(5)}</p>

--- a/frontend/src/app/Components/pins.json
+++ b/frontend/src/app/Components/pins.json
@@ -1,0 +1,803 @@
+[
+  {
+    "id": "1",
+    "lng": -74.5,
+    "lat": 40.0,
+    "title": "New York City",
+    "description": "The Big Apple",
+    "category": "city"
+  },
+  {
+    "id": "2",
+    "lng": -74.0,
+    "lat": 40.7,
+    "title": "Newark",
+    "description": "Newark Liberty International Airport",
+    "category": "airport"
+  },
+  {
+    "id": "3",
+    "lng": -75.0,
+    "lat": 39.9,
+    "title": "Philadelphia",
+    "description": "City of Brotherly Love",
+    "category": "city"
+  },
+  {
+    "id": "4",
+    "lng": -73.9,
+    "lat": 40.7,
+    "title": "Queens",
+    "description": "Borough of New York",
+    "category": "borough"
+  },
+  {
+    "id": "5",
+    "lng": -74.2,
+    "lat": 40.5,
+    "title": "Jersey City",
+    "description": "Across the Hudson",
+    "category": "city"
+  },
+  {
+    "id": "6",
+    "lng": -73.8,
+    "lat": 40.6,
+    "title": "Brooklyn",
+    "description": "The Borough of Kings",
+    "category": "borough"
+  },
+  {
+    "id": "7",
+    "lng": -74.8,
+    "lat": 40.3,
+    "title": "Trenton",
+    "description": "Capital of New Jersey",
+    "category": "city"
+  },
+  {
+    "id": "8",
+    "lng": -73.7,
+    "lat": 40.8,
+    "title": "Bronx",
+    "description": "The Bronx",
+    "category": "borough"
+  },
+  {
+    "id": "9",
+    "lng": -74.1,
+    "lat": 40.9,
+    "title": "Yonkers",
+    "description": "Gateway to the Hudson Valley",
+    "category": "city"
+  },
+  {
+    "id": "10",
+    "lng": -73.6,
+    "lat": 40.5,
+    "title": "Manhattan",
+    "description": "The Heart of NYC",
+    "category": "borough"
+  },
+  {
+    "id": "11",
+    "lng": -75.2,
+    "lat": 39.7,
+    "title": "Camden",
+    "description": "Across from Philadelphia",
+    "category": "city"
+  },
+  {
+    "id": "12",
+    "lng": -73.5,
+    "lat": 40.9,
+    "title": "Mount Vernon",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "13",
+    "lng": -74.3,
+    "lat": 40.2,
+    "title": "Princeton",
+    "description": "Home of Princeton University",
+    "category": "city"
+  },
+  {
+    "id": "14",
+    "lng": -73.4,
+    "lat": 40.4,
+    "title": "Staten Island",
+    "description": "The Forgotten Borough",
+    "category": "borough"
+  },
+  {
+    "id": "15",
+    "lng": -74.9,
+    "lat": 40.8,
+    "title": "Paterson",
+    "description": "Silk City",
+    "category": "city"
+  },
+  {
+    "id": "16",
+    "lng": -73.3,
+    "lat": 40.7,
+    "title": "New Rochelle",
+    "description": "Queen City of the Sound",
+    "category": "city"
+  },
+  {
+    "id": "17",
+    "lng": -74.4,
+    "lat": 40.1,
+    "title": "Toms River",
+    "description": "Jersey Shore",
+    "category": "city"
+  },
+  {
+    "id": "18",
+    "lng": -73.2,
+    "lat": 40.6,
+    "title": "White Plains",
+    "description": "Westchester County Seat",
+    "category": "city"
+  },
+  {
+    "id": "19",
+    "lng": -74.6,
+    "lat": 40.4,
+    "title": "Elizabeth",
+    "description": "Port City",
+    "category": "city"
+  },
+  {
+    "id": "20",
+    "lng": -73.1,
+    "lat": 40.5,
+    "title": "Hempstead",
+    "description": "Long Island",
+    "category": "city"
+  },
+  {
+    "id": "21",
+    "lng": -73.0,
+    "lat": 40.3,
+    "title": "Garden City",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "22",
+    "lng": -74.7,
+    "lat": 40.6,
+    "title": "Morristown",
+    "description": "Revolutionary War history",
+    "category": "city"
+  },
+  {
+    "id": "23",
+    "lng": -73.8,
+    "lat": 40.9,
+    "title": "New Rochelle",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "24",
+    "lng": -74.1,
+    "lat": 40.3,
+    "title": "Red Bank",
+    "description": "Jersey Shore town",
+    "category": "city"
+  },
+  {
+    "id": "25",
+    "lng": -73.9,
+    "lat": 40.8,
+    "title": "Pelham",
+    "description": "Westchester suburb",
+    "category": "city"
+  },
+  {
+    "id": "26",
+    "lng": -74.3,
+    "lat": 40.8,
+    "title": "Parsippany",
+    "description": "Morris County",
+    "category": "city"
+  },
+  {
+    "id": "27",
+    "lng": -73.7,
+    "lat": 40.3,
+    "title": "Freeport",
+    "description": "Long Island fishing village",
+    "category": "city"
+  },
+  {
+    "id": "28",
+    "lng": -74.5,
+    "lat": 40.7,
+    "title": "Summit",
+    "description": "Union County",
+    "category": "city"
+  },
+  {
+    "id": "29",
+    "lng": -73.6,
+    "lat": 40.8,
+    "title": "Scarsdale",
+    "description": "Westchester suburb",
+    "category": "city"
+  },
+  {
+    "id": "30",
+    "lng": -74.2,
+    "lat": 40.3,
+    "title": "Asbury Park",
+    "description": "Jersey Shore music scene",
+    "category": "city"
+  },
+  {
+    "id": "31",
+    "lng": -73.5,
+    "lat": 40.4,
+    "title": "Rockville Centre",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "32",
+    "lng": -74.8,
+    "lat": 40.5,
+    "title": "Flemington",
+    "description": "Hunterdon County",
+    "category": "city"
+  },
+  {
+    "id": "33",
+    "lng": -73.4,
+    "lat": 40.6,
+    "title": "Great Neck",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "34",
+    "lng": -74.4,
+    "lat": 40.9,
+    "title": "Wayne",
+    "description": "Passaic County",
+    "category": "city"
+  },
+  {
+    "id": "35",
+    "lng": -73.3,
+    "lat": 40.5,
+    "title": "Mineola",
+    "description": "Nassau County seat",
+    "category": "city"
+  },
+  {
+    "id": "36",
+    "lng": -74.6,
+    "lat": 40.2,
+    "title": "Brick",
+    "description": "Ocean County",
+    "category": "city"
+  },
+  {
+    "id": "37",
+    "lng": -73.2,
+    "lat": 40.7,
+    "title": "Port Chester",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "38",
+    "lng": -74.7,
+    "lat": 40.4,
+    "title": "Lakewood",
+    "description": "Ocean County",
+    "category": "city"
+  },
+  {
+    "id": "39",
+    "lng": -73.1,
+    "lat": 40.6,
+    "title": "Rye",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "40",
+    "lng": -74.9,
+    "lat": 40.6,
+    "title": "Clinton",
+    "description": "Hunterdon County",
+    "category": "city"
+  },
+  {
+    "id": "41",
+    "lng": -73.0,
+    "lat": 40.4,
+    "title": "Oceanside",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "42",
+    "lng": -74.1,
+    "lat": 40.8,
+    "title": "Ridgewood",
+    "description": "Bergen County",
+    "category": "city"
+  },
+  {
+    "id": "43",
+    "lng": -73.9,
+    "lat": 40.2,
+    "title": "Long Beach",
+    "description": "Long Island beach town",
+    "category": "city"
+  },
+  {
+    "id": "44",
+    "lng": -74.3,
+    "lat": 40.7,
+    "title": "Livingston",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "45",
+    "lng": -73.8,
+    "lat": 40.5,
+    "title": "Valley Stream",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "46",
+    "lng": -74.5,
+    "lat": 40.8,
+    "title": "Montclair",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "47",
+    "lng": -73.7,
+    "lat": 40.7,
+    "title": "Elmont",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "48",
+    "lng": -74.2,
+    "lat": 40.6,
+    "title": "Westfield",
+    "description": "Union County",
+    "category": "city"
+  },
+  {
+    "id": "49",
+    "lng": -73.6,
+    "lat": 40.6,
+    "title": "Floral Park",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "50",
+    "lng": -74.4,
+    "lat": 40.5,
+    "title": "Short Hills",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "51",
+    "lng": -73.5,
+    "lat": 40.8,
+    "title": "Bronxville",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "52",
+    "lng": -74.6,
+    "lat": 40.9,
+    "title": "Madison",
+    "description": "Morris County",
+    "category": "city"
+  },
+  {
+    "id": "53",
+    "lng": -73.4,
+    "lat": 40.3,
+    "title": "Lynbrook",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "54",
+    "lng": -74.8,
+    "lat": 40.7,
+    "title": "Chatham",
+    "description": "Morris County",
+    "category": "city"
+  },
+  {
+    "id": "55",
+    "lng": -73.3,
+    "lat": 40.8,
+    "title": "Tuckahoe",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "56",
+    "lng": -74.1,
+    "lat": 40.4,
+    "title": "Point Pleasant",
+    "description": "Jersey Shore",
+    "category": "city"
+  },
+  {
+    "id": "57",
+    "lng": -73.9,
+    "lat": 40.6,
+    "title": "Baldwin",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "58",
+    "lng": -74.3,
+    "lat": 40.6,
+    "title": "Maplewood",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "59",
+    "lng": -73.8,
+    "lat": 40.4,
+    "title": "Wantagh",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "60",
+    "lng": -74.5,
+    "lat": 40.6,
+    "title": "South Orange",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "61",
+    "lng": -73.7,
+    "lat": 40.8,
+    "title": "Eastchester",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "62",
+    "lng": -74.2,
+    "lat": 40.5,
+    "title": "Cranford",
+    "description": "Union County",
+    "category": "city"
+  },
+  {
+    "id": "63",
+    "lng": -73.6,
+    "lat": 40.5,
+    "title": "Franklin Square",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "64",
+    "lng": -74.4,
+    "lat": 40.4,
+    "title": "Millburn",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "65",
+    "lng": -73.5,
+    "lat": 40.7,
+    "title": "Pelham Manor",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "66",
+    "lng": -74.6,
+    "lat": 40.8,
+    "title": "Florham Park",
+    "description": "Morris County",
+    "category": "city"
+  },
+  {
+    "id": "67",
+    "lng": -73.4,
+    "lat": 40.4,
+    "title": "Seaford",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "68",
+    "lng": -74.8,
+    "lat": 40.6,
+    "title": "Bernardsville",
+    "description": "Somerset County",
+    "category": "city"
+  },
+  {
+    "id": "69",
+    "lng": -73.3,
+    "lat": 40.6,
+    "title": "New Hyde Park",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "70",
+    "lng": -74.1,
+    "lat": 40.3,
+    "title": "Belmar",
+    "description": "Jersey Shore",
+    "category": "city"
+  },
+  {
+    "id": "71",
+    "lng": -73.9,
+    "lat": 40.5,
+    "title": "Oceanside",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "72",
+    "lng": -74.3,
+    "lat": 40.5,
+    "title": "Verona",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "73",
+    "lng": -73.8,
+    "lat": 40.6,
+    "title": "Glen Cove",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "74",
+    "lng": -74.5,
+    "lat": 40.5,
+    "title": "Cedar Grove",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "75",
+    "lng": -73.7,
+    "lat": 40.7,
+    "title": "Harrison",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "76",
+    "lng": -74.2,
+    "lat": 40.4,
+    "title": "Spring Lake",
+    "description": "Jersey Shore",
+    "category": "city"
+  },
+  {
+    "id": "77",
+    "lng": -73.6,
+    "lat": 40.6,
+    "title": "Hicksville",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "78",
+    "lng": -74.4,
+    "lat": 40.6,
+    "title": "Nutley",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "79",
+    "lng": -73.5,
+    "lat": 40.8,
+    "title": "Mamaroneck",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "80",
+    "lng": -74.6,
+    "lat": 40.7,
+    "title": "Harding",
+    "description": "Morris County",
+    "category": "city"
+  },
+  {
+    "id": "81",
+    "lng": -73.4,
+    "lat": 40.5,
+    "title": "Levittown",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "82",
+    "lng": -74.8,
+    "lat": 40.5,
+    "title": "Far Hills",
+    "description": "Somerset County",
+    "category": "city"
+  },
+  {
+    "id": "83",
+    "lng": -73.3,
+    "lat": 40.7,
+    "title": "Larchmont",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "84",
+    "id": "84",
+    "lng": -74.1,
+    "lat": 40.2,
+    "title": "Manasquan",
+    "description": "Jersey Shore",
+    "category": "city"
+  },
+  {
+    "id": "85",
+    "lng": -73.9,
+    "lat": 40.4,
+    "title": "Massapequa",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "86",
+    "lng": -74.3,
+    "lat": 40.4,
+    "title": "Bloomfield",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "87",
+    "lng": -73.8,
+    "lat": 40.5,
+    "title": "Syosset",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "88",
+    "lng": -74.5,
+    "lat": 40.4,
+    "title": "North Caldwell",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "89",
+    "lng": -73.7,
+    "lat": 40.6,
+    "title": "Dobbs Ferry",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "90",
+    "lng": -74.2,
+    "lat": 40.3,
+    "title": "Sea Girt",
+    "description": "Jersey Shore",
+    "category": "city"
+  },
+  {
+    "id": "91",
+    "lng": -73.6,
+    "lat": 40.7,
+    "title": "Plainview",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "92",
+    "lng": -74.4,
+    "lat": 40.7,
+    "title": "West Caldwell",
+    "description": "Essex County",
+    "category": "city"
+  },
+  {
+    "id": "93",
+    "lng": -73.5,
+    "lat": 40.9,
+    "title": "Hastings-on-Hudson",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "94",
+    "lng": -74.6,
+    "lat": 40.6,
+    "title": "Long Hill",
+    "description": "Morris County",
+    "category": "city"
+  },
+  {
+    "id": "95",
+    "lng": -73.4,
+    "lat": 40.6,
+    "title": "Bethpage",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "96",
+    "lng": -74.8,
+    "lat": 40.4,
+    "title": "Peapack-Gladstone",
+    "description": "Somerset County",
+    "category": "city"
+  },
+  {
+    "id": "97",
+    "lng": -73.3,
+    "lat": 40.8,
+    "title": "Irvington",
+    "description": "Westchester County",
+    "category": "city"
+  },
+  {
+    "id": "98",
+    "lng": -74.1,
+    "lat": 40.1,
+    "title": "Spring Lake Heights",
+    "description": "Jersey Shore",
+    "category": "city"
+  },
+  {
+    "id": "99",
+    "lng": -73.9,
+    "lat": 40.3,
+    "title": "Farmingdale",
+    "description": "Long Island suburb",
+    "category": "city"
+  },
+  {
+    "id": "100",
+    "lng": -74.3,
+    "lat": 40.3,
+    "title": "Belleville",
+    "description": "Essex County",
+    "category": "city"
+  }
+] 

--- a/frontend/src/app/Components/types.d.ts
+++ b/frontend/src/app/Components/types.d.ts
@@ -1,0 +1,4 @@
+declare module "*.json" {
+  const value: any;
+  export default value;
+} 

--- a/frontend/src/app/Components/utils.ts
+++ b/frontend/src/app/Components/utils.ts
@@ -1,0 +1,37 @@
+export function debounce<T extends (...args: any[]) => any>(
+  func: T,
+  wait: number
+): (...args: Parameters<T>) => void {
+  let timeout: NodeJS.Timeout;
+  
+  return (...args: Parameters<T>) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
+}
+
+export interface Bounds {
+  sw: [number, number]; // southwest [lng, lat]
+  ne: [number, number]; // northeast [lng, lat]
+}
+
+export interface PinData {
+  id: string;
+  lng: number;
+  lat: number;
+  title: string;
+  description: string;
+  category: string;
+}
+
+export function isPointInBounds(
+  point: { lng: number; lat: number },
+  bounds: Bounds
+): boolean {
+  return (
+    point.lng >= bounds.sw[0] &&
+    point.lng <= bounds.ne[0] &&
+    point.lat >= bounds.sw[1] &&
+    point.lat <= bounds.ne[1]
+  );
+} 


### PR DESCRIPTION
	•	Pins render only within visible map bounds using getBounds()
	•	Pins update on moveend and zoomend events (300ms debounce)
	•	Uses local pins.json with 100 NYC points for testing
	•	Filters and renders pins dynamically; removes out-of-bound markers