### PR TITLE
Add backend submit-pin endpoint

### DIFF
--- a/backend/submit-pin.js
+++ b/backend/submit-pin.js
@@ -1,0 +1,72 @@
+// Backend API endpoint for pin submission
+// Accepts POST requests with pin data (latitude, longitude, and other fields)
+
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  serverTimestamp,
+} from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+
+const firebaseConfig = {
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID,
+  measurementId: process.env.FIREBASE_MEASUREMENT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const {
+    latitude,
+    longitude,
+    address,
+    numberOfOutlets,
+    powerType,
+    portType,
+    condition,
+    extraDetails,
+    imageUrl,
+  } = req.body;
+
+  if (
+    typeof latitude !== "number" ||
+    typeof longitude !== "number" ||
+    latitude < -90 ||
+    latitude > 90 ||
+    longitude < -180 ||
+    longitude > 180
+  ) {
+    res.status(400).json({ error: "Invalid latitude or longitude" });
+    return;
+  }
+
+  try {
+    const docRef = await addDoc(collection(db, "Outlets"), {
+      latitude,
+      longitude,
+      address: address || null,
+      numberOfOutlets: numberOfOutlets || null,
+      powerType: powerType || null,
+      portType: portType || null,
+      condition: condition || null,
+      extraDetails: extraDetails || null,
+      imageUrl: imageUrl || null,
+      createdAt: serverTimestamp(),
+    });
+    res.status(200).json({ success: true, id: docRef.id });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}

--- a/frontend/src/app/Components/Overlay.tsx
+++ b/frontend/src/app/Components/Overlay.tsx
@@ -543,12 +543,19 @@ const AddOutlet: React.FC<OverlayProps> = ({
                 onClick={async () => {
                   if (address !== "" && outletCount !== 0) {
                     try {
+                      // Get the authenticated user's UID (required by Firestore rules)
+                      const currentUser = auth.currentUser;
+                      if (!currentUser) {
+                        throw new Error("You must be signed in to add an outlet.");
+                      }
+                      const userId = currentUser.uid;
+
                       if (coords) {
                         await addOutlet({
                           latitude: coords.lat,
                           longitude: coords.lng,
                           userName: userName || "Anonymous",
-                          userId: userEmail || "unknown",
+                          userId: userId,
                           locationName: address,
                           chargerType: powerType || selectedPort,
                           description: `Condition: ${selectedCondition}. ${extraDetails}`,
@@ -556,7 +563,7 @@ const AddOutlet: React.FC<OverlayProps> = ({
                       } else {
                         await addOutletFrontend({
                           userName: userName || "Anonymous",
-                          userId: userEmail || "unknown",
+                          userId: userId,
                           locationName: address,
                           chargerType: powerType || selectedPort,
                           description: `Condition: ${selectedCondition}. ${extraDetails}`,
@@ -565,6 +572,7 @@ const AddOutlet: React.FC<OverlayProps> = ({
                       setShowAddOutlet(false);
                     } catch (err) {
                       console.error("Error submitting outlet:", err);
+                      alert(err instanceof Error ? err.message : "Failed to add outlet. Please try again.");
                     }
                   }
                 }}


### PR DESCRIPTION
Adds ``submit-pin.js``: a POST endpoint that validates incoming pin data (latitude/longitude + metadata) and saves it to the Firestore Outlets collection