### PR TITLE
Fix/disappearing pins and heatmap

### DIFF
--- a/frontend/src/app/Components/MapBox.tsx
+++ b/frontend/src/app/Components/MapBox.tsx
@@ -21,7 +21,36 @@ const pinsToGeoJSON = (pins: PinData[]): FeatureCollection<Point> => ({
 
 const HEATMAP_SOURCE_ID = "pins-heatmap-source";
 const HEATMAP_LAYER_ID  = "pins-heatmap-layer";
-const HEATMAP_MAX_ZOOM  = 9; // heatmap visible up to zoom 8
+const HEATMAP_MAX_ZOOM  = 9; // heatmap visible up to zoom 9
+
+// Helper function to map API data to PinData format
+const mapApiDataToPins = (data: any[]): PinData[] => {
+  return data
+    .filter((d: any) => typeof d.latitude === "number" && typeof d.longitude === "number")
+    .map((d: any, idx: number) => ({
+      id: d.id ?? String(idx),
+      lat: d.latitude,
+      lng: d.longitude,
+      title: d.locationName ?? "Outlet",
+      description: d.description ?? "",
+      category: d.chargerType ?? "",
+      fromDb: true,
+    }));
+};
+
+// Helper function to create marker element HTML
+const createMarkerElement = (): string => {
+  return `<img src="/images/pin_lightning.webp" style="width: 50px; height: 50px;" />`;
+};
+
+// Helper function to merge new pins with existing pins, avoiding duplicates
+const mergePinsWithoutDuplicates = (existingPins: PinData[], newPins: PinData[]): PinData[] => {
+  const existingIds = new Set(existingPins.map(p => p.id));
+  const uniqueNewPins = newPins.filter(p => !existingIds.has(p.id));
+  return [...existingPins, ...uniqueNewPins];
+};
+
+const PINDROP_MIN_ZOOM = 14;
 
 interface MapBoxProps {
   width?: string;

--- a/frontend/src/app/Components/MapBox.tsx
+++ b/frontend/src/app/Components/MapBox.tsx
@@ -317,6 +317,7 @@ const MapBox = forwardRef<{
         map.addSource(HEATMAP_SOURCE_ID, {
           type: "geojson",
           data: pinsToGeoJSON(pinsData),
+          cluster : false
         });
       }
 
@@ -328,20 +329,18 @@ const MapBox = forwardRef<{
           maxzoom: HEATMAP_MAX_ZOOM,
           paint: {
             "heatmap-weight": 1,
-            "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 1, 9, 3],
-            "heatmap-color": [
-              "interpolate",
-              ["linear"],
-              ["heatmap-density"],
-              0, "rgba(33,102,172,0)",
-              0.2, "rgb(103,169,207)",
-              0.4, "rgb(209,229,240)",
-              0.6, "rgb(253,219,199)",
-              0.8, "rgb(239,138,98)",
-              1, "rgb(178,24,43)"
-            ],
-            "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 4, 8, 8, 15],
-            "heatmap-opacity": ["interpolate", ["linear"], ["zoom"], 9, 1, 11, 0]
+            "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 1, 5,1.5, 9, 2, 11, 3],
+            "heatmap-color": ["interpolate",
+                              ["linear"],
+                              ["heatmap-density"],
+                              0, "rgba(0, 0, 0, 0)",
+                              0.3, "rgba(55, 126, 184, 0.2)",
+                              0.4, "rgba(102, 194, 165, 0.4)",
+                              0.6, "rgba(253, 231, 37, 0.6)",
+                              0.8, "rgba(248, 118, 109, 0.8)",
+                              1, "rgba(178, 24, 43, 1)"],
+            "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 1, 2, 4, 3, 8, 4, 12],
+            "heatmap-opacity": ["interpolate", ["linear"], ["zoom"], 7, 1, 9, 0.8, 10, 0.5, 11, 0]
           },
         });
       }

--- a/frontend/src/app/Components/MapBox.tsx
+++ b/frontend/src/app/Components/MapBox.tsx
@@ -21,7 +21,7 @@ const pinsToGeoJSON = (pins: PinData[]): FeatureCollection<Point> => ({
 
 const HEATMAP_SOURCE_ID = "pins-heatmap-source";
 const HEATMAP_LAYER_ID  = "pins-heatmap-layer";
-const HEATMAP_MAX_ZOOM  = 9; // heatmap visible up to zoom 10
+const HEATMAP_MAX_ZOOM  = 9; // heatmap visible up to zoom 8
 
 interface MapBoxProps {
   width?: string;

--- a/frontend/src/app/Components/MapBox.tsx
+++ b/frontend/src/app/Components/MapBox.tsx
@@ -21,7 +21,7 @@ const pinsToGeoJSON = (pins: PinData[]): FeatureCollection<Point> => ({
 
 const HEATMAP_SOURCE_ID = "pins-heatmap-source";
 const HEATMAP_LAYER_ID  = "pins-heatmap-layer";
-const HEATMAP_MAX_ZOOM  = 11; // heatmap visible up to zoom 10
+const HEATMAP_MAX_ZOOM  = 9; // heatmap visible up to zoom 10
 
 interface MapBoxProps {
   width?: string;
@@ -329,7 +329,7 @@ const MapBox = forwardRef<{
           maxzoom: HEATMAP_MAX_ZOOM,
           paint: {
             "heatmap-weight": 1,
-            "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 1, 5,1.5, 9, 2, 11, 3],
+            "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 0.8, 3, 1.2, 5, 1.5, 7, 1.8, 9, 2,],
             "heatmap-color": ["interpolate",
                               ["linear"],
                               ["heatmap-density"],
@@ -339,7 +339,7 @@ const MapBox = forwardRef<{
                               0.6, "rgba(253, 231, 37, 0.6)",
                               0.8, "rgba(248, 118, 109, 0.8)",
                               1, "rgba(178, 24, 43, 1)"],
-            "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 1, 2, 4, 3, 8, 4, 12],
+            "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 1, 1, 2, 2, 3, 4, 4, 6, 5, 8, 6, 12, 7, 16, 8, 18, 9, 20],
             "heatmap-opacity": ["interpolate", ["linear"], ["zoom"], 7, 1, 9, 0.8, 10, 0.5, 11, 0]
           },
         });
@@ -357,6 +357,7 @@ const MapBox = forwardRef<{
       // Zoom/heatmap toggle
       map.on("zoom", () => {
         const zoom = map.getZoom();
+        console.log(zoom)
         const showHeatmap = zoom < HEATMAP_MAX_ZOOM;
 
         if (map.getLayer(HEATMAP_LAYER_ID)) {
@@ -440,6 +441,52 @@ const MapBox = forwardRef<{
       : "mapbox://styles/hannahwiens/cmcj9t5wf000v01p6chg0e07a";
 
     mapRef.current.setStyle(newStyle);
+
+    //Readding heatmap after setting newStyle
+    mapRef.current.once('style.load', () => {
+      if (!mapRef.current) return;
+
+    if (!mapRef.current.getSource(HEATMAP_SOURCE_ID)) {
+      mapRef.current.addSource(HEATMAP_SOURCE_ID, {
+        type: "geojson",
+        data: pinsToGeoJSON(pinsData), 
+        cluster: false
+      });
+    }
+
+    if (!mapRef.current.getLayer(HEATMAP_LAYER_ID)) {
+        mapRef.current.addLayer({
+          id: HEATMAP_LAYER_ID,
+          type: "heatmap",
+          source: HEATMAP_SOURCE_ID,
+          maxzoom: HEATMAP_MAX_ZOOM,
+          paint: {
+            "heatmap-weight": 1,
+            "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 0.8, 3, 1.2, 5, 1.5, 7, 1.8, 9, 2,],
+            "heatmap-color": ["interpolate",
+                              ["linear"],
+                              ["heatmap-density"],
+                              0, "rgba(0, 0, 0, 0)",
+                              0.3, "rgba(55, 126, 184, 0.2)",
+                              0.4, "rgba(102, 194, 165, 0.4)",
+                              0.6, "rgba(253, 231, 37, 0.6)",
+                              0.8, "rgba(248, 118, 109, 0.8)",
+                              1, "rgba(178, 24, 43, 1)"],
+            "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 1, 1, 2, 2, 3, 4, 4, 6, 5, 8, 6, 12, 7, 16, 8, 18, 9, 20],
+            "heatmap-opacity": ["interpolate", ["linear"], ["zoom"], 7, 1, 9, 0.8, 10, 0.5, 11, 0]
+          },
+        });
+      }
+
+    const zoom = mapRef.current.getZoom();
+    if (zoom >= HEATMAP_MAX_ZOOM) {
+      const bounds = getBounds();
+      if (bounds) {
+        const pinsInView = filterPinsByBounds(bounds);
+        renderPins(pinsInView);
+      }
+    }
+  });
   }, [lightMode]);
   
 

--- a/frontend/src/app/Components/MapBox.tsx
+++ b/frontend/src/app/Components/MapBox.tsx
@@ -590,15 +590,17 @@ const MapBox = forwardRef<{
           paint: {
             "heatmap-weight": 1,
             "heatmap-intensity": ["interpolate", ["linear"], ["zoom"], 0, 0.8, 3, 1.2, 5, 1.5, 7, 1.8, 9, 2,],
-            "heatmap-color": ["interpolate",
-                              ["linear"],
-                              ["heatmap-density"],
-                              0, "rgba(0, 0, 0, 0)",
-                              0.3, "rgba(55, 126, 184, 0.2)",
-                              0.4, "rgba(102, 194, 165, 0.4)",
-                              0.6, "rgba(253, 231, 37, 0.6)",
-                              0.8, "rgba(248, 118, 109, 0.8)",
-                              1, "rgba(178, 24, 43, 1)"],
+            "heatmap-color": [
+              "interpolate",
+              ["linear"],
+              ["heatmap-density"],
+              0, "rgba(33,102,172,0)",
+              0.2, "rgb(103,169,207)",
+              0.4, "rgb(209,229,240)",
+              0.6, "rgb(253,219,199)",
+              0.8, "rgb(239,138,98)",
+              1, "rgb(178,24,43)"
+            ],
             "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 1, 1, 2, 2, 3, 4, 4, 6, 5, 8, 6, 12, 7, 16, 8, 18, 9, 20],
             "heatmap-opacity": ["interpolate", ["linear"], ["zoom"], 7, 1, 9, 0.8, 10, 0.5, 11, 0]
           },


### PR DESCRIPTION
# Fix: Heatmap Visibility and Light/Dark Mode Toggle Issues

## Problem
### Bug 1: 
At zoom levels after 9, the pins would disappear. This is because the HEATMAP_MAX_ZOOM was set to 11, causing pins to be hidden till zoom level 11
### Bug 2:
On toggling light/dark modes, the heatmap becomes no longer visible. This is because when toggling between light and dark modes, `setStyle()` completely replaces the map style, which removes all custom layers including the heatmap. This caused the heatmap to disappear and not reappear until the page was refreshed.

## Solutions
### Bug 1:
Changed HEATMAP_MAX_ZOOM from 11 to 9. 
This ensures that the heatmap is visible only till zoom level 9, and pins are visible from zoom levels 9+.
### Bug 2:
After 'setStyle()', the custom layers were added to ensure that the heatmap is visible after toggling light/dark mode.